### PR TITLE
Scope guard-main-branch hook to its own repo

### DIFF
--- a/_shared/claude-cli/hooks/guard-main-branch.test.ts
+++ b/_shared/claude-cli/hooks/guard-main-branch.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { HOOK_EXIT } from "../hooks.ts";
 import {
+	extractCdTarget,
 	isBranchMutatingCommand,
 	isProtectedBranch,
 } from "./guard-main-branch.ts";
@@ -26,6 +27,38 @@ describe("isProtectedBranch", () => {
 
 	test("returns false for fix branches", () => {
 		expect(isProtectedBranch("fix/typo")).toBe(false);
+	});
+});
+
+// -- extractCdTarget ---------------------------------------------------------
+
+describe("extractCdTarget", () => {
+	test("extracts unquoted path before &&", () => {
+		expect(extractCdTarget("cd /tmp/foo && git commit")).toBe("/tmp/foo");
+	});
+
+	test("extracts double-quoted path", () => {
+		expect(extractCdTarget('cd "/tmp/my dir" && git push')).toBe("/tmp/my dir");
+	});
+
+	test("extracts single-quoted path", () => {
+		expect(extractCdTarget("cd '/tmp/foo' && git commit")).toBe("/tmp/foo");
+	});
+
+	test("extracts path before ;", () => {
+		expect(extractCdTarget("cd /tmp/foo; git commit")).toBe("/tmp/foo");
+	});
+
+	test("returns null when no leading cd", () => {
+		expect(extractCdTarget("git commit -m 'test'")).toBeNull();
+	});
+
+	test("returns null when cd is mid-command", () => {
+		expect(extractCdTarget("git commit && cd /tmp")).toBeNull();
+	});
+
+	test("ignores leading whitespace", () => {
+		expect(extractCdTarget("  cd /tmp && git commit")).toBe("/tmp");
 	});
 });
 

--- a/_shared/claude-cli/hooks/guard-main-branch.ts
+++ b/_shared/claude-cli/hooks/guard-main-branch.ts
@@ -37,13 +37,41 @@ const BRANCH_MUTATION_PATTERNS: ReadonlyArray<RegExp> = [
 	/git\s+rebase\b/,
 ];
 
-export function getCurrentBranch(): string | null {
+export function getCurrentBranch(cwd?: string): string | null {
 	const result = Bun.spawnSync(["git", "symbolic-ref", "--short", "HEAD"], {
+		cwd,
 		stdout: "pipe",
 		stderr: "pipe",
 	});
 	if (result.exitCode !== 0) return null;
 	return result.stdout.toString().trim();
+}
+
+export function getRepoRoot(cwd?: string): string | null {
+	const result = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+		cwd,
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (result.exitCode !== 0) return null;
+	return result.stdout.toString().trim();
+}
+
+// Extract the target directory of a leading `cd <path> &&` (or `;`) clause.
+// Returns null if no leading cd is present. Quoted paths are unquoted.
+export function extractCdTarget(cmd: string): string | null {
+	const m = cmd.match(
+		/^\s*cd\s+("(?:[^"\\]|\\.)*"|'[^']*'|[^\s;&]+)\s*(?:&&|;)/,
+	);
+	if (!m) return null;
+	const raw = m[1] as string;
+	if (
+		(raw.startsWith('"') && raw.endsWith('"')) ||
+		(raw.startsWith("'") && raw.endsWith("'"))
+	) {
+		return raw.slice(1, -1);
+	}
+	return raw;
 }
 
 export function isProtectedBranch(branch: string): boolean {
@@ -69,7 +97,20 @@ if (import.meta.main) {
 
 	if (!isBranchMutatingCommand(cmd)) process.exit(HOOK_EXIT.ALLOW);
 
-	const branch = getCurrentBranch();
+	// If the command targets a different repo via a leading `cd`, only enforce
+	// when that repo is the same as the hook's project repo. Other repos have
+	// their own conventions and aren't ours to police.
+	const cdTarget = extractCdTarget(cmd);
+	const effectiveCwd = cdTarget ?? undefined;
+	if (cdTarget) {
+		const targetRoot = getRepoRoot(cdTarget);
+		const projectRoot = getRepoRoot();
+		if (targetRoot && projectRoot && targetRoot !== projectRoot) {
+			process.exit(HOOK_EXIT.ALLOW);
+		}
+	}
+
+	const branch = getCurrentBranch(effectiveCwd);
 	if (!branch || !isProtectedBranch(branch)) process.exit(HOOK_EXIT.ALLOW);
 
 	console.error(`BLOCKED: '${branch}' is a protected branch.`);


### PR DESCRIPTION
## Summary
- The `guard-main-branch` PreToolUse hook fired on every git commit/push, regardless of which repo the command targeted. Working in any other repo while claude-plugins sat on a protected branch (`main`/`master`) was getting blocked.
- Fix parses a leading `cd <path>` clause in the bash command, runs the toplevel/branch check against that effective cwd, and skips enforcement when the target repo's toplevel differs from claude-plugins'.
- Same policy still applies inside this repo. Other repos keep their own conventions.

## Test plan
- [x] All 47 existing + new unit tests pass (`bun test _shared/claude-cli/hooks/guard-main-branch.test.ts`)
- [x] Verified end-to-end: `cd ../agents-skills && git commit ...` from this session goes through, while a direct commit from the claude-plugins worktree on `main` is still blocked