### PR TITLE
Fix ascii-diagram test import path and bump CI actions off Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # full history needed for the drift guard
 
       - name: Set up tools (bun, lefthook via mise)
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       # Replays the local pre-commit checks server-side, so a `--no-verify`
       # commit can't slip a version desync or bad frontmatter past review.

--- a/scripts/__tests__/validate-ascii-diagrams.test.ts
+++ b/scripts/__tests__/validate-ascii-diagrams.test.ts
@@ -5,7 +5,7 @@ import {
 	findBoxes,
 	validateVerticalRuns,
 	type CodeBlock,
-} from "./validate-ascii-diagrams.ts";
+} from "../validate-ascii-diagrams.ts";
 
 // ── Helper: run vertical validation on raw diagram lines ─────
 function verticalIssues(diagram: string): string[] {


### PR DESCRIPTION
Resolves the two maintenance items flagged but intentionally deferred during the maintenance-hardening work (PR #19).

## Fix 1 — Test import path
`scripts/__tests__/validate-ascii-diagrams.test.ts` imported from `./validate-ascii-diagrams.ts`, but the script lives one directory up in `scripts/`. Corrected to `../validate-ascii-diagrams.ts`. The script already exports every imported symbol and guards its CLI with `import.meta.main`, so a side-effect-free import works.

- **Before:** `bun test` → 266 pass / 1 fail / 1 error (`Cannot find module './validate-ascii-diagrams.ts'`)
- **After:** `bun test` → 284 pass / 0 fail / 0 error (the ~18 ascii-diagram tests now run)

## Fix 2 — CI actions off Node 20
`actions/checkout@v4` and `jdx/mise-action@v2` both declare `runs.using: node20`. GitHub forces Node 24 on runners from 2026-06-16 and emits a deprecation annotation every run.

- `actions/checkout@v4` → `@v5` (node24)
- `jdx/mise-action@v2` → `@v4` (node24; only node24 major)

Verified via `gh api .../contents/action.yml?ref=<tag>` that both targets declare `using: node24`.

## Verification
- Local: `bun test` green (0 fail / 0 error).
- CI: this run should be green **and** the "Node.js 20 actions are deprecated" annotation gone.
- No regression: `validate-marketplace`, `validate-frontmatter --all`, and the main↔dev drift guard steps are unchanged.